### PR TITLE
Rails 6 and 7 compatibility

### DIFF
--- a/lib/pgpool_no_load_balance/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/pgpool_no_load_balance/active_record/connection_adapters/postgresql_adapter.rb
@@ -9,8 +9,8 @@ module PgpoolNoLoadBalance
 
         private
 
-        def to_sql_and_binds(arel_or_sql_string, binds=[])
-          sql, binds = super
+        def to_sql_and_binds(arel_or_sql_string, *args)
+          sql, binds = super(arel_or_sql_string, *args)
           if arel_or_sql_string.respond_to?(:pgpool_nlb?) && arel_or_sql_string.pgpool_nlb?
             sql = "#{NLB_COMMENT} #{sql}"
           end


### PR DESCRIPTION
Changed private method override to be compatible with rails 6 and 7. 

`to_sql_and_bindings` have 3 params since rails 6. 

https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L17