### PR TITLE
Make it compatible with Rails 7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,11 @@ straightforward as possible.
 ### Fixed
 
 ### Security
- 
+
+## [1.2.0] - 2025-08-28
+
+Rails 7.2 support
+
 ## [1.1.0] - 2020-06-14
  
 Executes any SQL statement with comments.

--- a/lib/pgpool_no_load_balance.rb
+++ b/lib/pgpool_no_load_balance.rb
@@ -12,7 +12,7 @@ module PgpoolNoLoadBalance
   class PostgreSQLAdapterMissing < StandardError; end
 
   def self.setup!
-    unless ::ActiveRecord::Base.respond_to?(:postgresql_connection)
+    unless defined?(::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
       raise PostgreSQLAdapterMissing, "No postgresql adapter specified by 'config/database.yml', or 'ActiveRecord::Base.establish_connection' method is not called."
     end
     ::ActiveRecord::Base.extend PgpoolNoLoadBalance::ActiveRecord::Querying

--- a/lib/pgpool_no_load_balance/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/pgpool_no_load_balance/active_record/connection_adapters/postgresql_adapter.rb
@@ -9,12 +9,12 @@ module PgpoolNoLoadBalance
 
         private
 
-        def to_sql_and_binds(arel_or_sql_string, binds = [], preparable = nil) # :nodoc:
-          sql, binds, preparable = super
+        def to_sql_and_binds(arel_or_sql_string, binds = [], preparable = nil, allow_retry = false) # :nodoc:
+          sql, binds, preparable, allow_retry = super
           if arel_or_sql_string.respond_to?(:pgpool_nlb?) && arel_or_sql_string.pgpool_nlb?
             sql = "#{NLB_COMMENT} #{sql}"
           end
-          [sql.freeze, binds, preparable]
+          [sql.freeze, binds, preparable, allow_retry]
         end
       end
     end

--- a/lib/pgpool_no_load_balance/active_record/relation/query_methods.rb
+++ b/lib/pgpool_no_load_balance/active_record/relation/query_methods.rb
@@ -15,7 +15,6 @@ module PgpoolNoLoadBalance
       end
 
       def pgpool_nlb_value=(value)
-        assert_mutability!
         @values[:pgpool_nlb] = value
       end
 

--- a/lib/pgpool_no_load_balance/version.rb
+++ b/lib/pgpool_no_load_balance/version.rb
@@ -1,3 +1,3 @@
 module PgpoolNoLoadBalance
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/pgpool_no_load_balance.gemspec
+++ b/pgpool_no_load_balance.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 5.2.0"
+  spec.add_dependency "activerecord", ">= 7.2.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "bundler/setup"
+require "active_record"
 require "pgpool_no_load_balance"
 
 RSpec.configure do |config|


### PR DESCRIPTION
```
PgpoolNoLoadBalance::PostgreSQLAdapterMissing: No postgresql adapter specified by 'config/database.yml', or 'ActiveRecord::Base.establish_connection' method is not called. (PgpoolNoLoadBalance::PostgreSQLAdapterMissing)
```